### PR TITLE
update content and style

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,12 +9,14 @@ is a community, service, and business
 powered by [Felt](https://github.com/feltcoop/felt),
 a set of free and open source tools for building
 customizable self-governing communities.
+
 Felt seeks to empower us,
 help us organize,
 and improve our communication —
 [Felt.social](https://felt.social) continues this mission
 by developing a sustainable business to
 foster communities that are effective, authentic, and humane.
+
 Our business is owned by a worker co-op
 and we're working to become
 a [platform co-op](https://platform.coop)

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ help us organize,
 and improve our communication —
 [Felt.social](https://felt.social) continues this mission
 by developing a sustainable business to
-foster communities that are effective, authentic, and humane.
+support communities that are effective, authentic, and humane.
 
 Our business is owned by a worker co-op
 and we're working to become

--- a/src/app.css
+++ b/src/app.css
@@ -7,6 +7,11 @@
 	--color_1_lightness: 44%;
 	--color_0: hsl(var(--color_0_hue), var(--color_0_saturation), var(--color_0_lightness));
 	--color_1: hsl(var(--color_1_hue), var(--color_1_saturation), var(--color_1_lightness));
+	--font_size_xxl: 48px;
+	--font_size_xl: 24px;
+	--font_size_lg: 20px;
+	--font_size_md: 16px;
+	--font_size_sm: 12px;
 }
 
 html {
@@ -23,29 +28,32 @@ body {
 	margin: 0;
 	font-family: Roboto, -apple-system, BlinkMacSystemFont, Segoe UI, Oxygen, Ubuntu, Cantarell,
 		Fira Sans, Droid Sans, Helvetica Neue, sans-serif;
-	font-size: 16px;
+	font-size: var(--font_size_md);
 	line-height: 1.2;
 	color: #2b2b2b;
 	background-color: #fff;
 }
 
-h1,
-h2,
-h3 {
+h1 {
+	font-size: var(--font_size_xl);
 	font-weight: 300;
+	margin: 0 0 16px;
 }
-
+h2 {
+	font-size: var(--font_size_lg);
+	margin: 0 0 8px;
+}
+h3 {
+	font-size: var(--font_size_md);
+	font-weight: bold;
+	margin: 0 0 4px;
+}
 h4,
 h5,
 h6 {
-	margin: 0 0 0.5em 0;
-	font-weight: normal;
-}
-
-h1 {
-	text-align: center;
-	font-size: 4em;
-	margin: 0 0 1em 0;
+	font-size: var(--font_size_sm);
+	font-weight: bold;
+	margin: 0 0 2px;
 }
 
 input,

--- a/src/app.css
+++ b/src/app.css
@@ -104,3 +104,10 @@ code {
 		14%
 	);
 }
+
+blockquote {
+	padding: 4px 0 4px 24px;
+	margin: 0 0 10px;
+	border-left: 8px solid #ccc;
+	color: hsl(0, 4%, 57%);
+}

--- a/src/lib/Header.svelte
+++ b/src/lib/Header.svelte
@@ -13,4 +13,8 @@
 	header {
 		text-align: center;
 	}
+	a {
+		display: block;
+		margin-bottom: 16px;
+	}
 </style>

--- a/src/lib/Intro.svelte
+++ b/src/lib/Intro.svelte
@@ -1,17 +1,29 @@
-<h2><a href="https://felt.social">Felt.social</a></h2>
-is a
-<small><code>work in progress</code></small>
-community, service, and business powered by
-<a href="https://github.com/feltcoop/felt">Felt</a>, a set of free and open source tools for
-building customizable self-governing communities. Felt seeks to empower us, help us organize, and
-improve our communication — Felt.social continues this mission by developing a sustainable business
-to foster communities that are effective, authentic, and humane. Our business is owned by a worker
-co-op and we're working to become a <a href="https://platform.coop">platform co-op</a>
-to best serve all stakeholders. We feel like accountability is pretty cool. If you think so too, we hope
-you'll join us!
+<p>
+	<a href="https://felt.social" class="title">Felt.social</a>
+	is a
+	<small><code>work in progress</code></small>
+	community, service, and business powered by
+	<a href="https://github.com/feltcoop/felt">Felt</a>, a set of free and open source tools for
+	building customizable self-governing communities.
+</p>
+<p>
+	Felt seeks to empower us, help us organize, and improve our communication — Felt.social continues
+	this mission by developing a sustainable business to foster communities that are effective,
+	authentic, and humane.
+</p>
+<p>
+	Our business is owned by a worker co-op and we're working to become a <a
+		href="https://platform.coop">platform co-op</a
+	>
+	to best serve all stakeholders. We feel like accountability is pretty cool. If you think so too, we
+	hope you'll join us!
+</p>
 
 <style>
-	h2 {
-		display: inline;
+	p {
+		text-align: center;
+	}
+	.title {
+		font-size: 24px;
 	}
 </style>

--- a/src/lib/Intro.svelte
+++ b/src/lib/Intro.svelte
@@ -8,7 +8,7 @@
 </p>
 <p>
 	Felt seeks to empower us, help us organize, and improve our communication — Felt.social continues
-	this mission by developing a sustainable business to foster communities that are effective,
+	this mission by developing a sustainable business to support communities that are effective,
 	authentic, and humane.
 </p>
 <p>

--- a/src/lib/LearnAboutFelt.svelte
+++ b/src/lib/LearnAboutFelt.svelte
@@ -1,4 +1,4 @@
-<a href="/about">learn → about ← Felt</a>
+<a href="/about">learn ¿ about ? Felt</a>
 
 <style>
 	a {

--- a/src/lib/LearnAboutFelt.svelte
+++ b/src/lib/LearnAboutFelt.svelte
@@ -1,4 +1,4 @@
-<a href="/about">learn ¿ about ? Felt</a>
+<a href="/about">¿ learn about Felt ?</a>
 
 <style>
 	a {

--- a/src/lib/LearnAboutFelt.svelte
+++ b/src/lib/LearnAboutFelt.svelte
@@ -2,6 +2,6 @@
 
 <style>
 	a {
-		font-size: 32px;
+		font-size: var(--font_size_xxl);
 	}
 </style>

--- a/src/lib/WeAreLive.svelte
+++ b/src/lib/WeAreLive.svelte
@@ -16,6 +16,6 @@
 		font-size: 32px;
 	}
 	.link {
-		font-size: 48px;
+		font-size: var(--font_size_xxl);
 	}
 </style>

--- a/src/routes/$layout.svelte
+++ b/src/routes/$layout.svelte
@@ -3,7 +3,7 @@
 </script>
 
 <svelte:head>
-	<link rel="shortcut icon" href="favicon.png" />
+	<link rel="shortcut icon" href="/favicon.png" />
 </svelte:head>
 
 <main>

--- a/src/routes/about.svelte
+++ b/src/routes/about.svelte
@@ -10,7 +10,7 @@
 
 <section>
 	<Header>
-		<h2>about Felt</h2>
+		<h1>about Felt</h1>
 	</Header>
 </section>
 <section>

--- a/src/routes/about.svelte
+++ b/src/routes/about.svelte
@@ -19,6 +19,7 @@
 		us, help us organize, and improve our communication. It's a free and open source alternative to
 		many websites and apps tucked into a warm fuzzy package.
 	</p>
+	<blockquote>tools for designing our digital lives</blockquote>
 	<p>
 		Our team is small and our goals are over the top. With the might of software we want to help
 		people solve priority problems with joy. Felt is what the web should be.

--- a/src/routes/about.svelte
+++ b/src/routes/about.svelte
@@ -54,7 +54,7 @@
 		right, Felt is tech that feels good.
 	</p>
 	<p>
-		Felt The Business makes money (or will!) by selling value to users. Mostly this is through
+		Felt The Business makes money (or will$$) by selling value to users. Mostly this is through
 		subscription services and commerce mediation like
 		<a href="https://felt.social">Felt.social</a>. We want a business model that keeps our
 		incentives aligned with our users, so we accept no revenue from third parties like advertisers.

--- a/src/routes/index.svelte
+++ b/src/routes/index.svelte
@@ -8,7 +8,7 @@
 
 <section>
 	<Header>
-		<h2>customizable communities that feel good</h2>
+		<h1>customizable communities that feel good</h1>
 	</Header>
 </section>
 <section>

--- a/src/routes/index.svelte
+++ b/src/routes/index.svelte
@@ -11,7 +11,7 @@
 		<h2>customizable communities that feel good</h2>
 	</Header>
 </section>
-<section class="intro">
+<section>
 	<Intro />
 </section>
 <section>
@@ -28,9 +28,5 @@
 	section {
 		margin-bottom: 40px;
 		max-width: 600px;
-	}
-	h2,
-	.intro {
-		text-align: center;
 	}
 </style>


### PR DESCRIPTION
This formats the intro text to three paragraphs instead of one, and refactors some styles. It also changes the word "foster" to "support". (changes welcome) It's deployed to felt.social via `gro deploy --branch paragraphs`

It also adds this tagline to the about page: 

> tools for designing our digital lives